### PR TITLE
Forces .sh files to have LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Default behavior
+* text=auto
+
+# Shell scripts must always have LF line endings
+*.sh text eol=lf


### PR DESCRIPTION
Adds .gitattributes file so that Git on Windows machines won't modify the shell script files to have CRLF line endings. 